### PR TITLE
Fix incorrect bower_components directory

### DIFF
--- a/lib/templates/browser/karma.conf.js
+++ b/lib/templates/browser/karma.conf.js
@@ -53,7 +53,11 @@ autoWatch = true;
 // - PhantomJS
 // - IE (only Windows)
 // CLI --browsers Chrome,Firefox,Safari
-browsers = ['PhantomJS'];
+browsers = [
+    'Chrome',
+    'Firefox',
+    'Safari'
+];
 
 // If browser does not capture in given timeout [ms], kill it
 // CLI --capture-timeout 5000


### PR DESCRIPTION
With the latest version of bower, `/components` is actually `/bower_components` so the tests were not finding chai after install.
