### PR TITLE
Fixes path to chai in browser generator

### DIFF
--- a/lib/templates/browser/karma.conf.js
+++ b/lib/templates/browser/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'components/chai/chai.js',
+      'bower_components/chai/chai.js',
       '<%= moduleFileName %>',
       'test/**/*.js'
     ],


### PR DESCRIPTION
Looks like the chai file path reverted back to `components` during the Karma update. This causes an error in the tests for browser generated modules.
